### PR TITLE
Bootstrap RFC process

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,0 +1,29 @@
+---
+start date: (fill me in with today’s date, YYYY-MM-DD)
+rfc_issue: (leave this empty)
+nanoc_issue: (leave this empty)
+---
+
+# Summary
+
+This is a one-paragraph explanation of the change.
+
+# Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Detailed design
+
+This is the bulk of the RFC. Explain the design in enough detail for somebody familiar with nanoc to understand, and for somebody familiar with nanoc’s internals to implement. This should get into specifics and corner-cases, and include examples of how the feature is used.
+
+# Drawbacks
+
+Why should we *not* do this?
+
+# Alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+# Unresolved questions
+
+What parts of the design are still to be discussed?

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# nanoc RFCs
+
+For nanoc 4, we’ve set up a process for collecting ideas and refining them before implementation. The RFC (_request for comment_) process is intended to provide a consistent and controlled path for new features to enter the product.
+
+## Proposing a change
+
+In order to propose a substantial change to nanoc, write a RFC, open a pull request, and get it accepted. In detail:
+
+0. Fork this repository.
+
+0. Copy _0000-template.md_ to _active/0000-description.md_, with _description_ replaced by a short description of the proposed change.
+
+0. Write the RFC. Fill in the necessary metadata at the top of the file.
+
+0. Submit a pull request.
+
+0. Collect and integrate feedback into the RFC.
+
+At some point after this, the RFC will either be accepted by merging the pull request and assigning the RFC a number, thereby marking the RFC as active, or rejected by closing the pull request.
+
+Modifications to active RFCs, if necessary, can be done in follow-up pull requests.
+
+Anyone is invited to participate in the RFC review process.
+
+## Implementing a change
+
+The author of an RFC is not obligated to implement it. Of course, the RFC author, like any other developer, is welcome to post an implementation for review after the RFC has been accepted.
+
+## Acknowledgements
+
+This nanoc RFC process is greatly inspired by the [Rust RFC process](https://github.com/rust-lang/rfcs) and the [Ember RFC process](https://github.com/emberjs/rfcs).


### PR DESCRIPTION
Inspired by the [Rust RFC process](https://github.com/rust-lang/rfcs) and the [Ember RFC process](https://github.com/emberjs/rfcs), here’s a stab at the nanoc RFC process.

This is intended to replace the nanoc 3 and nanoc 4 Trello boards. Both boards are outdated—especially the nanoc 4 one, since work on that project restarted from scratch. Trello does not integrate well with GitHub, and I find myself not looking often enough at the Trello boards (and I believe that is the case for other people too).

This process is not unlike the old [NEPs process](https://trello.com/b/dlEWOOBW/nanoc-4-0) (nanoc enhancement proposals). I believe the main drawback of that process is that it did not use pull request in order to collect feedback. The NEPs are also not quite as nicely structured: they often miss a summary, alternatives, open questions, and potential implications of having the feature.

For reference:

* [nanoc 3 Trello board](https://trello.com/b/qltxY5Cb/nanoc)
* [nanoc 4 Trello board](https://trello.com/b/dlEWOOBW/nanoc-4-0)

* * *

I have several ideas for RFCs in mind, which I’ll likely write up in the coming few weeks:

* Pluggable item output writer: Allow item reps to be written to other places than just the filesystem

* Intelligent item queries: Introduce a query DSL to get a better idea what dependencies certain items have, in order to improve dependency tracking

* Fine-grained dependency tracking: Allow items to depend on content or certain attributes of another, instead of the entire item itself, in order to reduce the number unnecessary recompilations.

* Parallel compilation: Compile multiple items at the same time, which should be beneficial for Ruby implementations that do not have a global interpreter lock.

* Pluggable colorisers: Instead of hardcoding colorisers in a single filter, split them out and allow other implementations to be plugged in.

* Merged compilation/routing rules: Allow a compilation rule to contain `#write` calls, which can make the Rules file more readable.

CC @nanoc/contributors 